### PR TITLE
Remove deprecated Bitnami common APIs

### DIFF
--- a/helm/templates/api/ingress.yaml
+++ b/helm/templates/api/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- include "common.tplvalues.render" (dict "value" .Values.api.ingress.annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
-  {{- if and .Values.api.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.api.ingress.ingressClassName }}
   ingressClassName: {{ .Values.api.ingress.ingressClassName | quote }}
   {{- end }}
   rules:

--- a/helm/templates/api/ingress.yaml
+++ b/helm/templates/api/ingress.yaml
@@ -28,9 +28,7 @@ spec:
           {{- toYaml .Values.api.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.api.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.api.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName"  (printf "%s-%s" .Release.Name "api") "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.api.ingress.extraHosts }}
@@ -38,9 +36,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s" .Release.Name "api") "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.api.ingress.extraRules }}

--- a/helm/templates/web/ingress.yaml
+++ b/helm/templates/web/ingress.yaml
@@ -28,9 +28,7 @@ spec:
           {{- toYaml .Values.web.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.web.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.web.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName"  (printf "%s-%s" .Release.Name "web")  "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.web.ingress.extraHosts }}
@@ -38,9 +36,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName"  (printf "%s-%s" .Release.Name "web")  "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.web.ingress.extraRules }}

--- a/helm/templates/web/ingress.yaml
+++ b/helm/templates/web/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- include "common.tplvalues.render" (dict "value" .Values.web.ingress.annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
-  {{- if and .Values.web.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.api.ingress.ingressClassName }}
   ingressClassName: {{ .Values.web.ingress.ingressClassName | quote }}
   {{- end }}
   rules:

--- a/helm/templates/ws/ingress.yaml
+++ b/helm/templates/ws/ingress.yaml
@@ -28,9 +28,7 @@ spec:
           {{- toYaml .Values.ws.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ws.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ws.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName"  (printf "%s-%s" .Release.Name "ws")  "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ws.ingress.extraHosts }}
@@ -38,9 +36,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName"  (printf "%s-%s" .Release.Name "ws")  "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ws.ingress.extraRules }}

--- a/helm/templates/ws/ingress.yaml
+++ b/helm/templates/ws/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- include "common.tplvalues.render" (dict "value" .Values.ws.ingress.annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
-  {{- if and .Values.ws.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.api.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ws.ingress.ingressClassName | quote }}
   {{- end }}
   rules:


### PR DESCRIPTION
The functions were removed from upstream. See https://github.com/bitnami/charts/blob/main/bitnami/common/CHANGELOG.md