### PR TITLE
fix extraVolumeMounts

### DIFF
--- a/helm/templates/web/deployment.yaml
+++ b/helm/templates/web/deployment.yaml
@@ -152,7 +152,7 @@ spec:
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.web.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.web.extraVolumeMounts }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.web.extraVolumeMounts "context" $) | nindent 12 }}
+          volumeMounts: {{- include "common.tplvalues.render" (dict "value" .Values.web.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
         {{- if .Values.web.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.web.sidecars "context" $) | nindent 8 }}

--- a/helm/templates/worker/deployment.yaml
+++ b/helm/templates/worker/deployment.yaml
@@ -208,7 +208,7 @@ spec:
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.worker.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.worker.extraVolumeMounts }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumeMounts "context" $) | nindent 12 }}
+          volumeMounts: {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
         {{- if .Values.worker.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.worker.sidecars "context" $) | nindent 8 }}

--- a/helm/templates/ws/deployment.yaml
+++ b/helm/templates/ws/deployment.yaml
@@ -166,7 +166,7 @@ spec:
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.ws.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.ws.extraVolumeMounts }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.ws.extraVolumeMounts "context" $) | nindent 12 }}
+          volumeMounts: {{- include "common.tplvalues.render" (dict "value" .Values.ws.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
         {{- if .Values.ws.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.ws.sidecars "context" $) | nindent 8 }}


### PR DESCRIPTION
# Description

The `extraVolumeMounts` config option was leading to invalid yaml due to missing `volumeMounts` key in the deployment specs.